### PR TITLE
AJ-12: Add pre-release banner

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -22,7 +22,18 @@ website:
     tools:
       - icon: github
         href:  https://github.com/nhsbsa-data-analytics/nhsbsa-analytical-code-assurance-playbook
-        
+
+  announcement: 
+    icon: info-circle
+    dismissable: true
+    content: '
+      **Pre-Release**: This is a new website under development.
+      [Click here](https://github.com/nhsbsa-data-analytics/nhsbsa-analytical-code-assurance-playbook/blob/main/CONTRIBUTE.md)
+      to find out how you can submit feedback, suggest improvements and get involved!
+      '
+    type: warning
+    position: above-navbar
+
   sidebar:
     style: "docked"
     search: false


### PR DESCRIPTION
# What?
Adds pre-release banner to the webpage

# Why?
To notify users that the website is in active development

# How?
Via [announcement bar](https://quarto.org/docs/websites/website-tools.html#announcement-bar) component

# Anything else?
Screenshot of webpage attached
![image](https://github.com/user-attachments/assets/cc0925b0-c730-4d9a-8462-bd4589f1d5df)
