### PR TITLE
AJ-11: add initial content from discussion thread

### DIFF
--- a/guidance/01-reproducible/pages/02-accessible.qmd
+++ b/guidance/01-reproducible/pages/02-accessible.qmd
@@ -1,6 +1,0 @@
----
-title: "Accessible"
-description: ""
----
-
-<!-- Generalised from readability: code should be readable *and* understandable by the intended audience.  -->

--- a/guidance/01-reproducible/pages/02-readable.qmd
+++ b/guidance/01-reproducible/pages/02-readable.qmd
@@ -1,0 +1,33 @@
+---
+title: "Readable"
+description: ""
+---
+
+> ### Pre-requisite reading
+>
+> * [AF Duck book: Readable code][duck-book]
+> * [NHSBSA DDaT playbook: Naming conventions][ddat-playbook]
+
+## What is readable code?
+Readable code is written with clarity and simplicity, making it easy for others to understand and maintain. It prioritises the reader's experience over the convenience of writing code.
+
+## Why should we write readable code?
+* Enhances team collaboration
+* Facilitates easier debugging and maintenance
+* Encourages best coding practices
+* Speeds up the onboading process for new team memebers
+
+## How do we write readable code?
+* Use clear and descriptive namees for variables and functions
+* Write small, reusable function that do one thing well
+* Comment wisely to explain the 'why', not the 'what'
+* Adhere to a consistent coding style
+* Regularly refactor to improve code clarity
+
+By following these guidelines, we create a codebase that is easier to read, understand, and contribute to, ultimately leading to a more efficient and effective development process. 
+For more detailed insights, please refer to the recommended pre-requisite reading.
+
+## How will this be enforced?
+
+[duck-book]: https://best-practice-and-impact.github.io/qa-of-code-guidance/readable_code.html
+[ddat-playbook]: https://nhsbsa.github.io/nhsbsa-digital-playbook/development/coding-naming-conventions/

--- a/guidance/01-reproducible/pages/03-modular.qmd
+++ b/guidance/01-reproducible/pages/03-modular.qmd
@@ -1,12 +1,12 @@
 ---
-title: "Modular Code and Workflows"
+title: "Modular"
 description: ""
 ---
 
-> Pre-requisite reading
+> ### Pre-requisite reading
 >
 > * [AF Duck book: Modular code][duck-book]
-> * [NHSBSA DDaT playbook: Development - Coding][coding-playbook]
+> * [NHSBSA DDaT playbook: Development - Coding][ddat-playbook]
 
 ## What is modular code?
 Complex analysis projects and workflows can often lead to a lot of code being written with some or a lot of that code performing repetitive tasks. 
@@ -77,5 +77,5 @@ However, they can be difficult to use with further practices for producing high 
 
 ## How will this be enforced?
 
-[coding-playbook]: https://nhsbsa.github.io/nhsbsa-digital-playbook/development/coding/
 [duck-book]: https://best-practice-and-impact.github.io/qa-of-code-guidance/modular_code.html
+[ddat-playbook]: https://nhsbsa.github.io/nhsbsa-digital-playbook/development/coding/

--- a/guidance/01-reproducible/pages/03-modular.qmd
+++ b/guidance/01-reproducible/pages/03-modular.qmd
@@ -1,4 +1,81 @@
 ---
-title: "Modular"
+title: "Modular Code and Workflows"
 description: ""
 ---
+
+> Pre-requisite reading
+>
+> * [AF Duck book: Modular code][duck-book]
+> * [NHSBSA DDaT playbook: Development - Coding][coding-playbook]
+
+## What is modular code?
+Complex analysis projects and workflows can often lead to a lot of code being written with some or a lot of that code performing repetitive tasks. 
+Breaking down your code and workflow into smaller reusable chunks to can help you maintain your project and share components across a series of analyses. 
+Tools such as R, Python, SQL, and Alteryx provide methods to create containerised code such as modules, classes, functions and macros.
+
+## Why should I do this?
+Writing your code in a modular way provides a range of benefits:
+
+* prevents long, complex walls of code that are hard to understand
+* makes sharing code with others (and your future self) easier
+* speeds up the peer review process 
+* makes testing of the code (and its outputs) easier
+
+## How do we do it then?
+Writing modular code or developing modular workflows can differ depending on the your tool of choice, the needs of the project or piece of work, the intended customer, or the expected users of the code in the future. 
+However, a simple hierarchy of actions to take are:
+
+* split complex code and workflows in multiple (ordered) scripts or smaller workflows
+* use a code notebook to organise your analysis
+* write re-usable code as functions
+* organise related functions into modules
+* organise and document modules as packages
+
+Let's dive into how we can do some of these.
+
+### Split your code into multiple scripts
+Monolithic code is a big no-no. A large and complex piece of code that runs into hundreds, if not thousands, of lines is unwieldy, difficult to read, debug and maintain, and pretty mean to pass off for peer review on a Friday afternoon. 
+Splitting your monolithic code into ordered scripts can help others (and yourself) understand the steps you've taken and the reasons why.
+
+<!-- DRAFT NOTE: intention here is to provide examples for the various tools that teams use e.g. R, Python, SQL, Alteryx, VBA (also need to be conscious of future data platform) -->
+
+For example, in R a large project could be split into:
+
+```
+project
+-- 01_data_build.R
+-- 02_data_clean.R
+-- 03_analysis.R
+-- 04_visualisation.R
+```
+
+these scripts can now be run in their intended order and splits out the parts of your code into related areas, making peer review easier.
+
+Using scripts doesn't inherently make your code reproducible or reusable, but are a good first step towards better and higher quality code.
+
+**Do**
+
+* split your code up
+* group related code together
+* organise your scripts so you and others know how to run it
+* make your scripts self contained and be able to ran from a command line
+
+**Don't**
+
+* write monolithic code
+* split up your code too much - 100 scripts with 10 lines of code in are just as hard to digest
+* write overly complex code where simpler solutions might exist
+
+### Use a code notebook
+Services such as Jupyter notebooks or R Markdown allow you write code, commentary and visualisations alongside each other. 
+They can be incredibly useful, and individual workbooks can be a good first step towards modularising your code for simple projects and workflows and for doing initial data exploration. 
+However, they can be difficult to use with further practices for producing high quality code. For example:
+
+* they are inherently difficult to review and audit using version control
+* code cells can be ran out of order, reducing reproducibility
+* not easy to test functions written in the notebook
+
+## How will this be enforced?
+
+[coding-playbook]: https://nhsbsa.github.io/nhsbsa-digital-playbook/development/coding/
+[duck-book]: https://best-practice-and-impact.github.io/qa-of-code-guidance/modular_code.html

--- a/guidance/02-quality-assured/pages/06-peer-reviewed.qmd
+++ b/guidance/02-quality-assured/pages/06-peer-reviewed.qmd
@@ -2,3 +2,86 @@
 title: "Peer-reviewed"
 description: ""
 ---
+
+> ### Pre-requisite reading
+> * [AF Duck Book: Peer review][duck-book]
+> * [NHSBSA DDaT Playbook: Development - Peer Review][ddat-playbook]
+
+## What is peer review?
+Peer review is a process where a second person will review a colleagues code before any code is finalised or used to produce output.
+
+## Why should I do this?
+Although peer reviews can reduce potential bugs being missed, the peer review process is not simply a case of trying to catch errors.
+
+There are a number of benefits that to using a peer review approach, including:
+
+* **Improving quality of code**: As part of the peer review process code will be reviewed to ensure that it is readable and understandable
+* **Sharing knowledge**: Review code can improve the knowledge of both the original code author and the reviewer
+* **Optimising code performance**: As part of the review process, different approaches may be found that could improve the code
+* **Find potential mistakes in the code**: Although peer review is not a replacement for testing, it can find potential bugs or issues in the code
+
+## How do we do it then?
+When using version control tools such as Git, peer review should be part of the branching and pull request process (see [DDaT Playbook][ddat-playbook]). 
+Ideally a pull request should not be merged without the code being reviewed by somebody else.
+
+Using version control tools the basic steps for a peer review are:
+<!-- DRAFT NOTE: do we need more details or is this repeating DDaT playbook -->
+
+1. Code author submits merge request relating for branch used to develop code
+1. Reviewer reviews the code and adds comments for any potential issues, including the following areas:
+    * Is the code readable and understandable?
+    * Is the code tested, and does the code do what it is designed for?
+    * Could the problem have been approached in a different way?
+1. Author reviews comments and amends code as needed
+    * Comments can and should be challenged if there is any disagreement to agree a resolution between the author and reviewer
+1. Reviewer approves amended code checking all issues have been resolved
+1. Branch merged
+
+**Do**
+
+* Try and incorporate peer review during the development process to get feedback during development
+* Communicate clearly to ensure both author and reviewer understand and are in agreement at each stage
+* Document any issues and decisions
+* Try running all code to ensure it works as designed
+
+**Don't**
+
+* Simply glance over code and accept if it "looks right"
+* Submit huge pull requests with multiple/large scripts where the reviewer has had not sight of the work previously
+* Blindly accept comments from a reviewer without making sure you agree with the comment
+* Be tempted to skip the review process to progress work quickly
+
+It would be strongly recommended that [version control][version-control] tools are implemented and used for all pieces of work 
+<!-- DRAFT NOTE: link to playbook section on version control -->
+However, where version control tools may not be in place, a peer review process would still be recommended, and notes should still be captured around any feedback and amendments raised during a review process.
+
+## Pair programming
+Instead of having the code writing and peer review as two distinct phases, pair programming combines these into a single step with two or more people actively working on the same piece of code at the same time. 
+Effective pair programming will involve one person writing the code whilst the other(s) supply real time feedback on the code being written.
+
+The benefits of pair programming are that feedback can be provided as the code is being written, suggesting improvements or identifying/fixing issues as they appear. Additionally, pair programming can be a good method to share knowledge and experience between individuals.
+
+Pair programming may require more resource during the development stage but at the benefit in a reduce of resource needed for a review stage.
+
+For pair programming to be effective there are guidelines that should be followed:
+
+### Rotate roles often
+
+Everyone should take turns writing and reviewing which could mean switching roles every 15-30 minutes. 
+This will ensure everyone gets experience from both sides of the process and will solidify the knowledge of the code being written.
+
+### Document large decisions
+
+Pair programming allows real-time discussion and decision making but where big decisions in terms of approach have been made these should still be documented for anybody who may use the code in future.
+
+### Be vocal and ask questions
+
+Pair programming is a collaborative process and should not just involve one person watching another code. 
+The person writing the code should be talking through what they are writing, and the reviewer should be supplying feedback and asking for clarification if there are parts that they do not understand. 
+Everybody who has been involved writing the code should have full understanding as if they had written it all themselves.
+
+## How will peer review be enforced?
+
+[duck-book]: https://best-practice-and-impact.github.io/qa-of-code-guidance/peer_review.html
+[ddat-playbook]: https://nhsbsa.github.io/nhsbsa-digital-playbook/development/coding/
+[version-control]: /guidance/01-reproducible/pages/04-version-controlled.qmd


### PR DESCRIPTION
# What?
Adds content on readable code, modular code and peer-review from the [original discussion thread](https://github.com/nhsbsa/nhsbsa-digital-playbook/discussions/253)

# Why?
To integrate these elements into the playbook. 

# How?
By lifting and shifting the content into the relevant placeholder page.

# Anything else?
The content has just been copied straight over. Review comments are provided below with my own suggestions. 
