### PR TITLE
48 add gitleaks guidance

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,18 @@
+name: gitleaks
+on: [pull_request, push, workflow_dispatch]
+jobs:
+  scan:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - run: wget -O gitleaks.toml https://raw.githubusercontent.com/nhsbsa-data-analytics/nhsbsaShinyR/main/gitleaks.toml
+
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITLEAKS_CONFIG: "gitleaks.toml"

--- a/guidance/05-open-source/pages/08-open-source.qmd
+++ b/guidance/05-open-source/pages/08-open-source.qmd
@@ -27,7 +27,7 @@ To publish analytical code:
 1. **Document your code:** Provide clear instructions for use, dependencies, and purpose.
 1. **Host on GitHub:** Host your code on the [NHSBSA Data Analytics GitHub][nhsbsa-github].
 1. **Follow NHSBSA guidance:** Adhere to [NHSBSA policies][nhsbsa-open-source] and approval processes for open source coding (only visible to internal NHSBSA colleagues).
-1. **Avoid storing secret keys or credentials in source code:** Use [secret management systems][secrets] and keep credentials out of repositories. Make sure you check the history as well as the current version of the codebase! See [GOV.UK guidance][govuk-secret-guidance].
+1. **Avoid storing secret keys or credentials in source code:** Use [secret management systems][gitleaks] and keep credentials out of repositories. Make sure you check the history as well as the current version of the codebase! See [GOV.UK guidance][govuk-secret-guidance].
 1. **Check for sensitive information:** Ensure no personal, confidential, or proprietary data is included. Make sure you check the history as well as the current version of the codebase!
 
 See the [GOV.UK Service Manual][govuk-service-manual] and [NHS Digital RAP Community guidance][rap-community-guidance] for detailed steps and best practices.

--- a/guidance/05-open-source/pages/08-open-source.qmd
+++ b/guidance/05-open-source/pages/08-open-source.qmd
@@ -27,7 +27,7 @@ To publish analytical code:
 1. **Document your code:** Provide clear instructions for use, dependencies, and purpose.
 1. **Host on GitHub:** Host your code on the [NHSBSA Data Analytics GitHub][nhsbsa-github].
 1. **Follow NHSBSA guidance:** Adhere to [NHSBSA policies][nhsbsa-open-source] and approval processes for open source coding (only visible to internal NHSBSA colleagues).
-1. **Avoid storing secret keys or credentials in source code:** Use secret management systems and keep credentials out of repositories. Make sure you check the history as well as the current version of the codebase! See [GOV.UK guidance][govuk-secret-guidance].
+1. **Avoid storing secret keys or credentials in source code:** Use [secret management systems][secrets] and keep credentials out of repositories. Make sure you check the history as well as the current version of the codebase! See [GOV.UK guidance][govuk-secret-guidance].
 1. **Check for sensitive information:** Ensure no personal, confidential, or proprietary data is included. Make sure you check the history as well as the current version of the codebase!
 
 See the [GOV.UK Service Manual][govuk-service-manual] and [NHS Digital RAP Community guidance][rap-community-guidance] for detailed steps and best practices.
@@ -70,17 +70,18 @@ For more details on licencing, see the [NHSBSA Digital Playbook][coding-licences
 * code that is difficult to understand or maintain.
 
 
-[fit-for-publishing]: https://nhsdigital.github.io/rap-community-of-practice/images/Fit_for_publishing_checklist.pdf
+[nhsbsa-open-data]: https://opendata.nhsbsa.net/
+[nhsbsa-github]: https://github.com/nhsbsa-data-analytics/
+[nhsbsa-open-source]: https://bsa2468.atlassian.net/wiki/spaces/OS/pages/3585835009/NHSBSA+Open+Source+Policy+FINAL #gitleaks:allow
+[gitleaks]: /guidance/05-open-source/pages/09-gitleaks.qmd
 [govuk-secret-guidance]: https://www.gov.uk/service-manual/technology/making-source-code-open-and-reusable#you-must-not-store-secret-keys-or-credentials-in-the-source-code
 [govuk-service-manual]: https://www.gov.uk/service-manual/technology/making-source-code-open-and-reusable#making-the-code-open
 [rap-community-guidance]: https://nhsdigital.github.io/rap-community-of-practice/implementing_RAP/publishing_code/how-to-publish-your-code-in-the-open/
+[nhsbsa-retro-open]: https://bsa2468.atlassian.net/wiki/spaces/OS/pages/3978821762/Retrospective+open+sourcing+REVIEW #gitleaks:allow
+[fit-for-publishing]: https://nhsdigital.github.io/rap-community-of-practice/images/Fit_for_publishing_checklist.pdf
 [apache-2]: https://www.apache.org/licenses/LICENSE-2.0
 [ogl-v3]: https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/
-[coding-licences]: https://nhsbsa.github.io/nhsbsa-digital-playbook/development/coding-licences/#ogl-v3
-[nhsbsa-open-data]: https://opendata.nhsbsa.net/
-[nhsbsa-github]: https://github.com/nhsbsa-data-analytics/
-[nhsbsa-open-source]: https://bsa2468.atlassian.net/wiki/spaces/OS/pages/3585835009/NHSBSA+Open+Source+Policy+FINAL
-[nhsbsa-retro-open]: https://bsa2468.atlassian.net/wiki/spaces/OS/pages/3978821762/Retrospective+open+sourcing+REVIEW
-[nhsbsa-footer-quarto]: https://github.com/nhsbsa-data-analytics/nhsbsa-analytical-code-assurance-playbook/blob/main/_quarto.yml#L70
 [nhsbsa-footer-shiny]: https://github.com/nhsbsa-data-analytics/nhsbsaShinyR/blob/main/R/nhs_footer.R
+[nhsbsa-footer-quarto]: https://github.com/nhsbsa-data-analytics/nhsbsa-analytical-code-assurance-playbook/blob/main/_quarto.yml#L70
 [nhsbsa-footer-js]: https://github.com/nhsbsa/nhsbsa-digital-playbook/tree/main/lib/_components/appFooter
+[coding-licences]: https://nhsbsa.github.io/nhsbsa-digital-playbook/development/coding-licences/#ogl-v3

--- a/guidance/05-open-source/pages/09-gitleaks.qmd
+++ b/guidance/05-open-source/pages/09-gitleaks.qmd
@@ -1,0 +1,84 @@
+---
+title: "Gitleaks"
+description: "Automatically scan for secrets when pushing code to GitHub"
+---
+
+## `gitleaks`
+
+It is best practice to set up a [`gitleaks`][gitleaks] secret scanning action when using GitHub. The GitHub organisation [`nhsbsa-data-analytics`][github-org] account contains a publicly accessible [`gitleaks` config file][config] for the action, which has some custom rules. This extends the standard config used by `gitleaks`.
+
+Use of `gitleaks` is free, however a license key is required for organisations.
+
+### GitHub action setup
+
+To get a license key:
+
+1. Visit [gitleaks.io][gitleaks-io].
+1. Click the Sign-up button.
+1. Fill in the form.
+1. You will be emailed a license key.
+1. Add this key as a secret named `GITLEAKS_LICENSE` by navigating to your organisation's actions page (the page will be https://github.com/organizations/{YOUR_ORGANISATION}/settings/secrets/actions/)
+
+Note that this organisation level secret will only be visible from public repositories. For any private repositories, you will need to add the license key at the repository level itself, again named `GITLEAKS_LICENSE` (the page will be https://github.com/nhsbsa-data-analytics/{PRIVATE_REPOSITORY}/settings/secrets/actions).
+
+To add an action that will run whenever code is pushed to a repo:
+
+1. If not already there, create a file in the root directory of your repo named `.github` (note the '.'!).
+1. Within the `.github` folder, and if not already present, create another folder named `workflows`.
+1. Create a file in `workflows` named `gitleaks.yml`.
+1. Paste the following into `gitleaks.yml`:
+
+```
+name: gitleaks
+on: [pull_request, push, workflow_dispatch]
+jobs:
+  scan:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - run: wget -O gitleaks.toml https://raw.githubusercontent.com/nhsbsa-data-analytics/nhsbsaShinyR/main/gitleaks.toml
+
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITLEAKS_CONFIG: "gitleaks.toml"
+
+```
+
+### Handling false positives
+
+Rarely you might get a false positive when the `gitleaks` action runs. To handle this, simply add a comment to ignore the line:
+
+```
+My fake NHS number is 1234567890 #gitleaks:allow
+```
+
+### Handling exposed secrets
+
+If you have pushed a secret to a public GitHub repository **assume that the secret is now public knowledge**.
+
+1. Triage: If the secret is a credential of some sort, immediately take action to revoke, delete or change it.
+1. Cleanup: Remove the secret from your repository history.
+1. Prevention: Consider if there are any actions you can take in future to minimise the chance of revealing a secret.
+
+See detailed instructions for [removing sensitive data from a repository][remove-sensitive-data].
+
+One thing that can reduce the chance of an exposure is to check your code before you even make a commit. This can be done by setting up a [pre-commit hook][hook] that runs `gitleaks` every time you make a commit.
+
+## Additional measures
+
+You should enable [push protection][push-protection] at the `GitHub` organisation level. It is also possible to schedule [secret scanning][secret-scanning] on your repositories. Push protection and secret scanning are always available for free on public repositories, but they are a paid-tier service for any private repos. The methods used in these services are similar to `gitleaks`, but are proprietary to GitHub. Most major cloud service providers and many API providers are partners with GitHub. This means GitHub can sometimes send a suspect token to a partner to verify if it's an active, valid credential before even alerting the user.
+
+[gitleaks]: https://github.com/gitleaks/gitleaks
+[github-org]: https://github.com/nhsbsa-data-analytics
+[config]: https://github.com/nhsbsa-data-analytics/nhsbsaShinyR/blob/main/gitleaks.toml
+[gitleaks-io]: https://gitleaks.io/
+[remove-sensitive-data]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository
+[hook]: https://github.com/gitleaks/gitleaks?tab=readme-ov-file#pre-commit
+[push-protection]: https://docs.github.com/en/code-security/secret-scanning/introduction/about-push-protection
+[secret-scanning]: https://docs.github.com/en/code-security/secret-scanning/introduction/about-secret-scanning


### PR DESCRIPTION
# What?
Adds a page on gitleaks, and general secret management

# Why?
Practical and important aspect of open source coding

# How?
Describes what gitleaks is, how to add an action that will use it when code is pushed and how to handle both false positives and real exposures. Also mentions other GitHub services that are available for public repos.

# Anything else?
I added a GHA for gitleaks to help me write the content. This also led me to make an update to improve the config we have in place in the nhsbsaShinyR repo (the config is linked to for all our gitleaks GHA's).
